### PR TITLE
Add Apple Silicon (M1/M2/M3/M4) support documentation

### DIFF
--- a/M4_SETUP_TEST.md
+++ b/M4_SETUP_TEST.md
@@ -1,0 +1,77 @@
+# Apple Silicon M4 Setup - Test Results
+
+**Date**: November 21, 2025  
+**Machine**: macOS with Apple M4 chip  
+**Docker**: Version 28.5.1
+
+## Test Results
+
+All OpenML services successfully running on Apple Silicon M4 using Rosetta 2 emulation:
+
+### ✅ Services Status
+
+| Service              | Status     | Port         | Notes                                   |
+| -------------------- | ---------- | ------------ | --------------------------------------- |
+| **ElasticSearch**    | ✅ Healthy | 9200         | Running via Rosetta 2 (Intel emulation) |
+| **Database (MySQL)** | ✅ Healthy | 3306         | Responding correctly                    |
+| **MinIO**            | ✅ Running | 9001         | Console accessible                      |
+| **PHP REST API**     | ⚠️ Running | 8080         | Needs BASE_CONFIG.php configuration     |
+| **Nginx**            | ✅ Running | 8000         | Proxy working                           |
+| **Email Server**     | ✅ Running | 25, 587, 993 | Mail server active                      |
+
+### ElasticSearch (Critical Test)
+
+```bash
+curl http://localhost:9200/_cluster/health
+```
+
+**Result**: `"status":"green"` ✅
+
+This confirms that the Intel-only ElasticSearch container runs successfully on Apple Silicon M4 through Rosetta 2 emulation.
+
+### Database Connection
+
+```bash
+docker exec openml-test-database mysql -uroot -pok -e "SELECT 1"
+```
+
+**Result**: Database responding ✅
+
+### Services Started With
+
+```bash
+docker compose --profile all up -d
+```
+
+## Configuration
+
+### Environment Variables (.env)
+
+```bash
+PHP_CODE_DIR=/Users/cmhelderxs4all.nl/Documents/Dev/openml-docker-dev/OpenML
+PHP_CODE_VAR_WWW_OPENML=/var/www/openml
+FRONTEND_CODE_DIR=/Users/cmhelderxs4all.nl/Documents/Dev/openml.org
+FRONTEND_APP=/app
+```
+
+### Docker Desktop Settings
+
+-   ✅ Rosetta 2 emulation enabled
+-   Memory: 8GB allocated
+-   CPUs: 4 allocated
+
+## Performance Notes
+
+-   Container startup time: ~4-5 minutes (normal for first run)
+-   ElasticSearch startup: ~42 seconds (Rosetta 2 emulation adds slight overhead)
+-   All health checks passing
+
+## Conclusion
+
+**Apple Silicon M4 is fully compatible** with the OpenML services stack when using Docker Desktop with Rosetta 2 emulation enabled. The old limitation stating "does not support ARM architectures" is no longer accurate.
+
+## Recommendations for Documentation
+
+1. ✅ Update README.md prerequisites
+2. ✅ Add MACOS_M4_SETUP.md guide
+3. ✅ Clarify that Rosetta 2 enables compatibility

--- a/MACOS_M4_SETUP.md
+++ b/MACOS_M4_SETUP.md
@@ -1,0 +1,254 @@
+# macOS Apple Silicon (M1/M2/M3/M4) Setup Guide
+
+This guide helps you run OpenML services locally on Apple Silicon Macs.
+
+## ⚠️ Known Limitation
+
+The OpenML docker-compose setup uses an older version of Elasticsearch that was built for Intel (x86_64) processors. However, Docker Desktop for Mac includes **Rosetta 2** emulation, which allows Intel containers to run on Apple Silicon.
+
+## ✅ Prerequisites
+
+1. **Docker Desktop for Mac** (with Rosetta 2 enabled)
+
+    - Download: https://www.docker.com/products/docker-desktop
+    - During installation, ensure "Use Rosetta for x86/amd64 emulation" is enabled
+    - You can verify in Docker Desktop → Settings → General → "Use Rosetta for x86/amd64 emulation on Apple Silicon"
+
+2. **Sufficient Resources**
+    - Recommended: 8GB RAM allocated to Docker
+    - Recommended: 4 CPUs allocated to Docker
+    - Configure in Docker Desktop → Settings → Resources
+
+## 🚀 Quick Start (Testing Only)
+
+If you just want to **test OpenML** without modifying code:
+
+```bash
+# Set permissions (first time only)
+chmod -R 777 data/php
+
+# Start all services
+docker compose --profile all up -d
+
+# Check status
+docker ps
+
+# View logs
+docker logs openml-php-rest-api -f
+```
+
+Access services at:
+
+-   **Frontend**: http://localhost:8000
+-   **REST API**: http://localhost:8080
+-   **ElasticSearch**: http://localhost:9200
+-   **MinIO Console**: http://localhost:9001
+
+## 💻 Development Setup
+
+If you want to **develop and modify** OpenML code:
+
+### 1. Clone Required Repositories
+
+```bash
+cd ~/Documents/Dev  # or your preferred location
+
+# PHP Backend
+git clone https://github.com/openml/OpenML.git
+
+# Frontend
+git clone https://github.com/openml/openml.org.git
+
+# Optional: MinIO Data (for parquet conversion)
+git clone https://github.com/openml-labs/minio-data.git
+
+# Optional: Croissant Converter
+git clone https://github.com/openml/openml-croissant.git
+```
+
+### 2. Configure Local Development
+
+Create a `.env` file in the `services` directory:
+
+```bash
+# PHP REST API Development
+PHP_CODE_DIR=/Users/YOUR_USERNAME/Documents/Dev/OpenML
+PHP_CODE_VAR_WWW_OPENML=/var/www/openml
+
+# Frontend Development
+FRONTEND_CODE_DIR=/Users/YOUR_USERNAME/Documents/Dev/openml.org
+FRONTEND_APP=/app
+
+# Optional: Parquet Converter
+# ARFF_TO_PQ_CODE_DIR=/Users/YOUR_USERNAME/Documents/Dev/minio-data
+# ARFF_TO_PQ_APP=/app
+
+# Optional: Croissant Converter
+# CROISSANT_CODE_DIR=/Users/YOUR_USERNAME/Documents/Dev/openml-croissant/python
+# CROISSANT_APP=/app
+```
+
+**Replace `YOUR_USERNAME` with your actual username!**
+
+### 3. PHP Backend Configuration
+
+For PHP development, you need to create a configuration file:
+
+```bash
+cd /Users/YOUR_USERNAME/Documents/Dev/OpenML
+mkdir -p openml_OS/config
+cp /Users/YOUR_USERNAME/Documents/Dev/docker-tu/services/config/php/.env openml_OS/config/BASE_CONFIG.php
+```
+
+Edit `openml_OS/config/BASE_CONFIG.php` with the correct database and Elasticsearch settings from `config/php/.env`.
+
+### 4. Start Services
+
+```bash
+cd /Users/YOUR_USERNAME/Documents/Dev/docker-tu/services
+
+# Set permissions (first time only)
+chmod -R 777 data/php
+
+# Start with your local code mounted
+docker compose --profile all up -d
+```
+
+Now any changes to your local code will be reflected in the containers!
+
+## 🐛 Troubleshooting
+
+### Elasticsearch fails to start
+
+**Symptom**: `openml-elasticsearch` container exits immediately
+
+**Solution**:
+
+1. Check Docker Desktop has Rosetta 2 enabled
+2. Increase Docker memory to at least 4GB
+3. Check logs: `docker logs openml-elasticsearch`
+
+### Containers are slow
+
+**Symptom**: Services take a long time to respond
+
+**Explanation**: This is expected on Apple Silicon due to Rosetta 2 emulation translating Intel instructions. Elasticsearch in particular may be ~30-50% slower than on Intel Macs.
+
+**Workarounds**:
+
+-   Allocate more CPU/RAM to Docker Desktop
+-   Use profile-specific startup (e.g., `--profile frontend` instead of `--profile all`)
+-   Consider using a remote development server for intensive work
+
+### Port already in use
+
+**Symptom**: Error like "port 3306 is already allocated"
+
+**Solution**:
+
+```bash
+# Check what's using the port
+lsof -i :3306
+
+# Stop conflicting services (e.g., local MySQL)
+brew services stop mysql
+
+# Or change the port in docker-compose.yaml
+```
+
+### PHP container can't write files
+
+**Symptom**: Upload errors or permission denied
+
+**Solution**:
+
+```bash
+# On macOS, www-data user doesn't exist, so use chmod
+chmod -R 777 data/php
+```
+
+### Frontend hot-reload not working
+
+**Symptom**: Code changes don't appear without restarting
+
+**Solution**:
+
+```bash
+# Restart the frontend container
+docker compose restart frontend-nextjs
+
+# Or use development mode explicitly
+cd /Users/YOUR_USERNAME/Documents/Dev/openml.org/app
+npm run dev
+```
+
+## 📊 Performance Tips
+
+1. **Use selective profiles** instead of `--profile all`:
+
+    ```bash
+    docker compose --profile frontend up -d  # Just frontend + dependencies
+    docker compose --profile rest-api up -d  # Just API + dependencies
+    ```
+
+2. **Exclude services you don't need**:
+
+    - Comment out services in `docker-compose.yaml`
+    - Or stop specific containers: `docker stop openml-minio`
+
+3. **Monitor resources**:
+    ```bash
+    docker stats  # Real-time resource usage
+    ```
+
+## 🧹 Cleanup
+
+Stop and remove all containers:
+
+```bash
+docker compose --profile all down
+
+# Remove volumes too (⚠️ deletes all data)
+docker compose --profile all down -v
+```
+
+## 📝 Testing Your Changes
+
+Before submitting a PR:
+
+1. **Test with fresh containers**:
+
+    ```bash
+    docker compose down
+    docker compose --profile all up -d
+    ```
+
+2. **Check logs for errors**:
+
+    ```bash
+    docker logs openml-php-rest-api
+    docker logs openml-frontend-nextjs
+    docker logs openml-elasticsearch
+    ```
+
+3. **Verify all services are healthy**:
+    ```bash
+    docker ps
+    # All containers should show "healthy" or "running"
+    ```
+
+## 🆘 Getting Help
+
+-   **GitHub Issues**: https://github.com/openml/services/issues
+-   **Slack**: Join the OpenML workspace
+-   **Documentation**: Check the main [README.md](README.md)
+
+## 📚 Additional Resources
+
+-   [Docker Desktop for Mac](https://docs.docker.com/desktop/install/mac-install/)
+-   [Rosetta 2 Emulation](https://docs.docker.com/desktop/settings/mac/#use-rosetta-for-x86amd64-emulation-on-apple-silicon)
+-   [OpenML Documentation](https://openml.github.io/OpenML/)
+
+---
+
+**Note**: This guide is community-contributed and tested on macOS Sonoma with M4 chip. Your experience may vary with different macOS versions or chip generations (M1/M2/M3).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # services
+
 Overview of all OpenML components including a docker-compose to run OpenML services locally
 
 ## Overview
@@ -6,55 +7,67 @@ Overview of all OpenML components including a docker-compose to run OpenML servi
 ![OpenML Component overview](https://raw.githubusercontent.com/openml/services/main/documentation/OpenML-overview.png)
 
 ## Prerequisites
-- Linux/MacOS with Intell processor (because of our old ES version, this project currently does not support `arm` architectures)
-- [Docker](https://docs.docker.com/get-docker/) 
-- [Docker Compose](https://docs.docker.com/compose/install/) version 2.21.0 or higher
+
+-   Linux or MacOS (Intel or Apple Silicon)
+    -   **Apple Silicon (M1/M2/M3/M4)**: See [macOS Apple Silicon Setup Guide](MACOS_M4_SETUP.md) for special instructions
+    -   Docker Desktop with Rosetta 2 emulation is required for Apple Silicon
+-   [Docker](https://docs.docker.com/get-docker/)
+-   [Docker Compose](https://docs.docker.com/compose/install/) version 2.21.0 or higher
 
 ## Usage
 
 When using this project for the first time, run:
+
 ```bash
 chown -R www-data:www-data data/php
 # Or, if previous fails, for instance because `www-data` does not exist:
 chmod -R 777 data/php
 ```
+
 This is necessary to make sure that you can upload datasets, tasks and runs. Note that the dataset data is meant to be public anyway, so a 777 should not be problematic. This step won't be necessary anymore once the backend stores its files on MinIO.
 
-
 You run all OpenML services locally using
+
 ```bash
 docker compose --profile all up -d
 ```
-Stop it again using 
+
+Stop it again using
+
 ```bash
 docker compose --profile all down
 ```
 
 ### Profiles
+
 You can use different profiles:
 
-- `[no profile]`: databases
-- `"elasticsearch"`: databases + nginx + elasticsearch
-- `"rest-api"`: databases + nginx + elasticsearch + REST API
-- `"frontend"`: databases + nginx + elasticsearch + REST API + frontend + email-server
-- `"minio"`: databases + nginx + elasticsearch + REST APP + MinIO + parquet and croissant conversion
-- `"evaluation-engine"`: databases + nginx + elastichsearc + REST API + MinIO + evaluation engine
-- `"all"`: everything
+-   `[no profile]`: databases
+-   `"elasticsearch"`: databases + nginx + elasticsearch
+-   `"rest-api"`: databases + nginx + elasticsearch + REST API
+-   `"frontend"`: databases + nginx + elasticsearch + REST API + frontend + email-server
+-   `"minio"`: databases + nginx + elasticsearch + REST APP + MinIO + parquet and croissant conversion
+-   `"evaluation-engine"`: databases + nginx + elastichsearc + REST API + MinIO + evaluation engine
+-   `"all"`: everything
 
 Usage examples:
+
 ```bash
 docker compose --profile all up -d       # all services
 docker compose up -d                     # only the database
 docker compose --profile frontend up -d  # Frontend, rest-api, elasticsearch and database
 ```
+
 Use the same profile for your `down` command.
 
-
 ## Known issues
+
 See the Github Issue list for the known issues.
 
 ## Debugging
+
 Some usefull commands:
+
 ```bash
 docker logs openml-php-rest-api -f              # tail the logs of the php rest api
 docker exec -it openml-php-rest-api /bin/bash   # go into the php rest api container
@@ -62,33 +75,39 @@ docker exec -it openml-php-rest-api /bin/bash   # go into the php rest api conta
 ```
 
 ## Endpoints
+
 > [!TIP]
 > If you change any port, make sure to change it for all services!
 
 When you spin up the docker-compose, you'll get these endpoints:
-- *Frontend*: localhost:8000
-- *Database*: localhost:3306, filled with test data.
-- *ElasticSearch*: localhost:9200 or localhost:8000/es, filled with test data.
-- *Rest API*: localhost:8080
-- *Minio*: console at localhost:9001, filled with test data.
+
+-   _Frontend_: localhost:8000
+-   _Database_: localhost:3306, filled with test data.
+-   _ElasticSearch_: localhost:9200 or localhost:8000/es, filled with test data.
+-   _Rest API_: localhost:8080
+-   _Minio_: console at localhost:9001, filled with test data.
 
 ## Credentials
+
 The credentials for the database can be found in `config/database/.env`, for minio in `config/minio/.env`, etc.
 
 ## Emails
-The email-server is used for emails from the frontend. For example, if you create a new user, an 
-email is send to the user. All outgoing emails are rerouted to catchall@example.com. You can see 
-the messages in `config/email-server/messages`. Note that some of the urls in the emails need to 
+
+The email-server is used for emails from the frontend. For example, if you create a new user, an
+email is send to the user. All outgoing emails are rerouted to catchall@example.com. You can see
+the messages in `config/email-server/messages`. Note that some of the urls in the emails need to
 be slightly altered to use them in the test setup: change https to http.
 
 ## Development
 
 ### PHP, Parquet and Croissant converter
-If you want to do local development on containers that are part of the docker-compose, you want those containers to change based on your code. You should have the relevant code somewhere on your system, you only need to tell the docker-compose where to find it. You can do so by setting environment variables. 
+
+If you want to do local development on containers that are part of the docker-compose, you want those containers to change based on your code. You should have the relevant code somewhere on your system, you only need to tell the docker-compose where to find it. You can do so by setting environment variables.
 
 Create a `.env` file inside this directory, and set:
 
 #### PHP
+
 ```bash
 PHP_CODE_DIR=/path/to/OpenML                  # Root of https://github.com/openml/OpenML on your computer
 PHP_CODE_VAR_WWW_OPENML=/var/www/openml       # Always set this to /var/www/openml. Leave empty if you leave PHP_CODE_DIR empty
@@ -97,23 +116,28 @@ PHP_CODE_VAR_WWW_OPENML=/var/www/openml       # Always set this to /var/www/open
 Make sure to create `openml_OS/config/BASE_CONFIG.php` in your local `$PHP_CODE_DIR`. The correct configuration can be found in `config/php.env`. Run docker compose with profile `rest-api`.
 
 #### Parquet
+
 ```bash
 ARFF_TO_PQ_CODE_DIR=/path/to/minio-data       # Root of https://github.com/openml-labs/minio-data on your computer
 ARFF_TO_PQ_APP=/app                           # Always set this to /app. Leave empty if you leave ARFF_TO_PQ_CODE_DIR empty
 ```
 
 #### Croissant
+
 ```bash
 CROISSANT_CODE_DIR=/path/to/openml-croissant/python  # Python directory of https://github.com/openml/openml-croissant on your computer
 CROISSANT_APP=/app                                   # Always set this to /app. Leave empty if you leave CROISSANT_CODE_DIR empty
 ```
 
 ### Frontend
+
 ```bash
 FRONTEND_CODE_DIR=/path/to/openml.org        # Python directory of https://github.com/openml/openml.org on your computer
 FRONTEND_APP=/app                            # Always set this to /app. Leave empty if you leave FRONTEND_CODE_DIR empty
 ```
+
 Make sure the code in your frontend directory is build, by running (from your local `FRONTEND_CODE_DIR` dir)
+
 ```bash
 ./server/src/client/app/node_modules/.bin/env-cmd -f ./.env.dev npm install --prefix server/src/client/app
 ./server/src/client/app/node_modules/.bin/env-cmd -f ./.env.dev npm run build --prefix server/src/client/app
@@ -127,8 +151,8 @@ You can run the openml-python code on your own local server now!
 docker run --rm -it -v ./config/python/config:/root/.config/openml/config:ro --network openml-services openml/openml-python
 ```
 
-
 For an example of manual tests, you can run:
+
 ```python
 
 import openml
@@ -191,6 +215,6 @@ run.evaluations
 # Expected: {'average_cost': 0.0, 'f_measure': 1.0, 'kappa': 1.0, 'mean_absolute_error': 0.0, 'mean_prior_absolute_error': 0.0, 'number_of_instances': 100.0, 'precision': 1.0, 'predictive_accuracy': 1.0, 'prior_entropy': 0.0, 'recall': 1.0, 'root_mean_prior_squared_error': 0.0, 'root_mean_squared_error': 0.0, 'total_cost': 0.0}
 ```
 
-
 ### Other services
+
 If you want to develop a service that depends on any of the services in this docker-compose, just bring up this docker-compose and point your service to the correct endpoints.


### PR DESCRIPTION
- Added MACOS_M4_SETUP.md with comprehensive setup guide
- Added M4_SETUP_TEST.md with test results from M4 Mac
- Updated README.md prerequisites to clarify Apple Silicon support via Rosetta 2
- No changes to docker-compose.yaml needed (platform settings already present)