### PR TITLE
[DOC] Improve Development Setup Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Backend
-This guide is applicable to APIv1, please find the APIv2 setup guide [here](https://docs.openml.org/apiv2/contributing/contributing/).
-
 Overview of all OpenML components including a docker-compose to run OpenML services locally. 
+The Python-based REST API (or REST API version 2) is still experimental, the other services are used in production.
+
+Note: For the development of the Python-based REST API, a separate definition of services is currently maintained. These are in that repository, see the [Python REST API](https://docs.openml.org/apiv2/contributing/contributing/) documentation for more information.
 
 ## Overview
 


### PR DESCRIPTION
Currently the [docs page](https://docs.openml.org/services/) for setting up v1 backend using `services` assume that the user is already aware of the `services` repo. This can be confusing for new users or contributors since they primarily look at `OpenML` repo for v1 backend code. 
This PR adds the installation instruction for `services` repo in the development instructions.